### PR TITLE
Updating with adding external library functionality and generation of…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cmwalk.egg-info
+cmwalk/__pycache__/

--- a/cmwalk/SubDir_CMakeLists_Library.txt.jinja2
+++ b/cmwalk/SubDir_CMakeLists_Library.txt.jinja2
@@ -1,0 +1,22 @@
+{% if files|length > 0 %}
+# add source and header files when compiling the given target.
+# although it is not necessary to add header files, we also do that for easing the management of IDE.
+target_sources(${CURRENT_LIB_NAME}
+    PUBLIC
+    {% for fname in files %}
+        ${CMAKE_CURRENT_LIST_DIR}/{{ fname }}
+    {% endfor %}
+)
+
+{% endif %}
+{% if addToCompilerIncludeDirectories %}
+# add current directory to the compiler included directories when compiling the given target.
+target_include_directories(${CURRENT_LIB_NAME} PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
+
+{% endif %}
+{% if subdirs|length > 0 %}
+# load and run the CMake code from subdirectories for current target.
+{% for subdir in subdirs %}
+include(${CMAKE_CURRENT_LIST_DIR}/{{ subdir }}/CMakeLists.txt)
+{% endfor %}
+{% endif %}

--- a/cmwalk/TopLevel_CMakeLists_Library.txt.jinja2
+++ b/cmwalk/TopLevel_CMakeLists_Library.txt.jinja2
@@ -16,9 +16,9 @@ include({{ cfg.cmakeCompilerOptionsFile }})
 
 {% endif %}
 
-# export the executable target through a variable to CMakeLists.txt files in subdirectories.
+# export the library target through a variable to CMakeLists.txt files in subdirectories.
 # update the dependent sources.
-add_executable(${PROJECT_NAME}
+add_library(${PROJECT_NAME}
 {%  if files|length > 0 %}
 {% for fname in files %}
     {{ fname }}
@@ -43,27 +43,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE {{ include }})
 ""
 {% endif %}
 
+
 {% if subdirs|length > 0 %}
-# export the name of executable target via a variable to CMakeLists.txt files in subdirectories.
-set(CURRENT_EXE_NAME ${PROJECT_NAME})
+# export the name of library target via a variable to CMakeLists.txt files in subdirectories.
+set(CURRENT_LIB_NAME ${PROJECT_NAME})
 # load and run the CMake code from subdirectories for current target.
 {% for subdir in subdirs %}
 include({{ subdir }}/CMakeLists.txt)
 {% endfor %}
 {% endif %}
-
-
-# if compiler is GNU gcc/g++, then generate *.bin & *.hex files.
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-    # generate the hex file from the built target.
-    set(HEX_FILE ${PROJECT_NAME}.hex)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${PROJECT_NAME}> ${HEX_FILE}
-        COMMENT "Building ${HEX_FILE}...")
-
-    # generate the bin file from the built target.
-    set(BIN_FILE ${PROJECT_NAME}.bin)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${PROJECT_NAME}> ${BIN_FILE}
-        COMMENT "Building ${BIN_FILE}...")
-endif()

--- a/cmwalk/TopLevel_CMakeLists_Library.txt.jinja2
+++ b/cmwalk/TopLevel_CMakeLists_Library.txt.jinja2
@@ -18,7 +18,9 @@ include({{ cfg.cmakeCompilerOptionsFile }})
 
 # export the library target through a variable to CMakeLists.txt files in subdirectories.
 # update the dependent sources.
-add_library(${PROJECT_NAME}
+
+# Configuration for dynamic library
+add_library(${PROJECT_NAME} SHARED
 {%  if files|length > 0 %}
 {% for fname in files %}
     {{ fname }}
@@ -47,6 +49,43 @@ target_link_libraries(${PROJECT_NAME} PRIVATE {{ include }})
 {% if subdirs|length > 0 %}
 # export the name of library target via a variable to CMakeLists.txt files in subdirectories.
 set(CURRENT_LIB_NAME ${PROJECT_NAME})
+# load and run the CMake code from subdirectories for current target.
+{% for subdir in subdirs %}
+include({{ subdir }}/CMakeLists.txt)
+{% endfor %}
+{% endif %}
+
+
+# Configuration for static library
+add_library(${PROJECT_NAME}-static
+{%  if files|length > 0 %}
+{% for fname in files %}
+    {{ fname }}
+{% endfor %}
+{% else %}
+    ""
+{% endif %}
+)
+
+if (LINKER_SCRIPT)
+	# if linker script is defined, make the target to depends on it,
+	# so the target will be rebuilt when linker script was changed.
+    set_target_properties(${PROJECT_NAME}-static PROPERTIES LINK_DEPENDS ${LINKER_SCRIPT})
+endif()
+
+{% if cfg.includeLibraries|length > 0 %}
+{% for include in cfg.includeLibraries %}
+# Add external explicit libraries. Such as 'm' for libm (math.h).
+target_link_libraries(${PROJECT_NAME}-static PRIVATE {{ include }})
+{% endfor %}
+{% else %}
+""
+{% endif %}
+
+
+{% if subdirs|length > 0 %}
+# export the name of library target via a variable to CMakeLists.txt files in subdirectories.
+set(CURRENT_LIB_NAME ${PROJECT_NAME}-static)
 # load and run the CMake code from subdirectories for current target.
 {% for subdir in subdirs %}
 include({{ subdir }}/CMakeLists.txt)

--- a/cmwalk/cmwalk.py
+++ b/cmwalk/cmwalk.py
@@ -64,7 +64,11 @@ class CmWalk(object):
         :return: the full path name of generated CMakeLists.txt.
         """
 
+        projName = os.path.basename(os.path.abspath(working_path))
+
         if cfg:
+            if "projectName" in cfg.keys():
+                projName = cfg['projectName']
             if 'includeLibraries' in cfg.keys():
                 includedLibraries = []
                 for lib in cfg['includeLibraries']:
@@ -72,7 +76,7 @@ class CmWalk(object):
 
         fnameOut = os.path.join(working_path, 'CMakeLists.txt')
         template = self.envJinja.get_template(self.TOP_LEVEL_CMAKELISTS_JINJA2_TEMPLATE)
-        fcontent = template.render({'project_name':os.path.basename(os.path.abspath(working_path)),
+        fcontent = template.render({'project_name':projName,
                                     'subdirs': subdirs,
                                     'files': files,
                                     'cfg': cfg})

--- a/cmwalk/cmwalk.py
+++ b/cmwalk/cmwalk.py
@@ -13,7 +13,7 @@ from . import version
 def parseArgs():
     description = "A python script to generate CMakeLists.txt of a C/C++ project - v{}.".format(version.VERSION)
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument('-l', '--library', help='Generate CMakeLists for Library.', action='store_true')
+    parser.add_argument('-l', '--library', help='Generate CMakeLists for both shared and static Library.', action='store_true')
     parser.add_argument('input_dir', help='The base directory of C/C++ project.')
     args = parser.parse_args()
     return args
@@ -113,7 +113,8 @@ def main():
 
     cmwalk = CmWalk()
 
-    if (args.library):
+    if (args.library): 
+        print("Generating CMakeLists.txt for libraries")
         cmwalk.TOP_LEVEL_CMAKELISTS_JINJA2_TEMPLATE = 'TopLevel_CMakeLists_Library.txt.jinja2'
         cmwalk.SUBDIR_CMAKELISTS_JINJA2_TEMPLATE = 'SubDir_CMakeLists_Library.txt.jinja2'
 

--- a/cmwalk/cmwalk.py
+++ b/cmwalk/cmwalk.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import argparse
+from xml.etree.ElementInclude import include
 from jinja2 import Environment, FileSystemLoader
 import json
 import walkdir # https://walkdir.readthedocs.io/en/stable/#
@@ -12,6 +13,7 @@ from . import version
 def parseArgs():
     description = "A python script to generate CMakeLists.txt of a C/C++ project - v{}.".format(version.VERSION)
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('-l', '--library', help='Generate CMakeLists for Library.', action='store_true')
     parser.add_argument('input_dir', help='The base directory of C/C++ project.')
     args = parser.parse_args()
     return args
@@ -62,6 +64,12 @@ class CmWalk(object):
         :return: the full path name of generated CMakeLists.txt.
         """
 
+        if cfg:
+            if 'includeLibraries' in cfg.keys():
+                includedLibraries = []
+                for lib in cfg['includeLibraries']:
+                    includedLibraries.append(lib)
+
         fnameOut = os.path.join(working_path, 'CMakeLists.txt')
         template = self.envJinja.get_template(self.TOP_LEVEL_CMAKELISTS_JINJA2_TEMPLATE)
         fcontent = template.render({'project_name':os.path.basename(os.path.abspath(working_path)),
@@ -100,6 +108,10 @@ def main():
                               included_files=['*.s', '*.cpp', '*.c', '*.cxx', '*.h', '*.hpp'])
 
     cmwalk = CmWalk()
+
+    if (args.library):
+        cmwalk.TOP_LEVEL_CMAKELISTS_JINJA2_TEMPLATE = 'TopLevel_CMakeLists_Library.txt.jinja2'
+        cmwalk.SUBDIR_CMAKELISTS_JINJA2_TEMPLATE = 'SubDir_CMakeLists_Library.txt.jinja2'
 
     dir_depth = 0
     for working_path, subdirs, files in it:


### PR DESCRIPTION
… libraries instead of executables.

Probably not the most elegant method, but this adds the functionality of passing the "-l" argument to generate the CMakeLists.txt for a library instead of an executable. Also adds support for "includeLibraries" key in cmwalk.json to include external libraries, for example:
```
{
"includeLibraries": ["m"]
}
```

generate the following in CMakeLists.txt:
```
# Add external explicit libraries. Such as 'm' for libm (math.h).
target_link_libraries(${PROJECT_NAME} PRIVATE m)
```
This includes the libm libraries (which includes the commonly used "math.h" library) which normally wouldn't be included by default.